### PR TITLE
Bring Onboarding process docs to GitHub

### DIFF
--- a/Onboarding.md
+++ b/Onboarding.md
@@ -14,7 +14,6 @@ If it's not been done already, you or your team onboarding buddy should follow t
 
 - Amazon Web Services (AWS) – the infrastructure (IaaS) provider we use
 - Authority to Operate (ATO) - approval from an agency's Authorizing Official to run a digital service under FISMA
-- AWS – Amazon Web Services
 - Azure – Microsoft's PaaS. They are regular contributors to various cloud.gov components.
 - BOSH (rhymes with "squash") – the configuration/server management tool we use to run Cloud Foundry. Basically, it's what keeps the platform running.
 - BOSH Lite – [https://github.com/cloudfoundry/bosh-lite](https://github.com/cloudfoundry/bosh-lite)


### PR DESCRIPTION
[Repurposing Chris' existing issue to represent this work. -Bret]

In order to get new members of the cloud.gov productive quickly, we want concise lists of materials for them to review which will bring them up to speed.

Acceptance Criteria

- [ ] There's an Onboarding Checklist in the `cg-product` repository, and all other materials point at it rather than the Trello board.
- [ ] The list contains tasks for all new people as well as tasks specific to particular workstreams.
- [ ] The list includes directions on creating an issue to track the progress of the new person's ramp-up

---

Chris originally said:

> AWS was listed twice.