### PR TITLE
Add direct link to board for Atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here are the streams of work we've identified so far and the products for which 
   - The Liberator stream aims to make infrastructure and deployment self-service and easy to use, and ensure people can find answers when they need them.
   - Liberator encompasses all the user- and tenant-facing features of cloud.gov. That includes documentation, web UI, onboarding and billing workflow, as well as overall design and branding.
 
-We keep separate backlogs, kanban boards, etc. reflecting each of these streams of work. The [`cg-product` kanban board](https://github.com/18F/cg-product#boards) consolidates the activity of all of these sub-streams into a single view as they fan out into assorted GitHub repositories. 
+We keep separate backlogs, kanban boards, etc. reflecting each of these streams of work. The [`cg-product` kanban board](https://github.com/18F/cg-product#boards) consolidates the activity of all of these sub-streams into a single view as they fan out into assorted GitHub repositories. To get a view reflecting only one of the streams, use the label filter above the board.
 
 Other notable Slack channels for 18F folk
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When we're well-staffed, we break into sub-teams around the different streams, b
 
 Here are the streams of work we've identified so far and the products for which they're responsible.
 
-- [Atlas](https://github.com/18F/cg-atlas) (#cloud-gov-atlas)
+- [Atlas](https://github.com/18F/cg-product#boards?labels=Atlas&showPRs=false) (#cloud-gov-atlas)
   - The Atlas stream aims to keep a solid, dependable, tested, and proven platform up and running strong for everyone in government to use. This includes a lot of automation; infrastructure-as-code is the key theme.
   - "cloud.gov" commonly refers to the [cloud.gov](https://cloud.gov) Platform-as-a-Service (PaaS), which was cloud.gov's first product. The PaaS provides a comfortable abstraction which handles cloud-based operations and greatly reduces the complications of infrastructure management for delivery teams. Our PaaS builds on the widely-used and open source [Cloud Foundry](https://www.cloudfoundry.org/), deployed with practices geared toward meeting [strict government compliance requirements](https://en.wikipedia.org/wiki/Federal_Information_Security_Management_Act_of_2002).
   - This stream includes activity to establish FEDRAMP recognition of cloud.gov, and publishes [machine-friendly descriptions of cloud.gov security controls](https://github.com/18F/cg-compliance). Compliance auditing and pen-testing activities are coordinated here, as well as necessary remediation that results.


### PR DESCRIPTION
I'm reworking the main board to incorporate **all** our repositories and labeling issues by substream so that one can easily filter using just the label drop-down. I'll also be adding some direct links to pre-filtered views to make it easier for people not familiar with ZenHub.