### PR TITLE
remove "squishy" language around what services Atlas gets access to

### DIFF
--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -95,6 +95,6 @@ In order to get NewPerson productively contributing to the cloud.gov team, Buddy
 ### Atlas-specific items
 - [ ] Ask `#admins-github` to have them added to the [@18F/cloud-gov-team](https://github.com/orgs/18F/teams/cloud-gov-ops) team on GitHub **(For contractors: Confirm they have cleared GSA security review before doing this one!)**
 - [ ] If the new person is a contractor, ask `#admins-github` to have them added to the [@18F/cloud-gov-contractors](https://github.com/orgs/18F/teams/cloud-gov-contractors) team on GitHub
-- [ ] Grant them access to the following (where applicable): AWS, New Relic, PagerDuty, StatusPage
-- [ ] Take them through [AWS onboarding](https://docs.cloud.gov/ops/aws-onboarding/) (if applicable)
+- [ ] Grant them access to the following: AWS, New Relic, PagerDuty, StatusPage
+- [ ] Take them through [AWS onboarding](https://docs.cloud.gov/ops/aws-onboarding/)
 - [ ] Give them a walkthrough of cloud.gov from an architecture and repository perspective


### PR DESCRIPTION
This is needed for FedRAMP, because we need to definitively know what services people get access to.

Pairing with @linuxbozo, in support of https://github.com/18F/cg-product/issues/280 (specifically `AC-2(e)`).