### PR TITLE
Add notes about DigitalGov Search to onboarding and offboarding

### DIFF
--- a/OffboardingChecklist.md
+++ b/OffboardingChecklist.md
@@ -29,8 +29,9 @@ In order to complete LeavingPerson's exit from the cloud.gov team, the assignee 
 - [ ] Remove them from [the cloud.gov support Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!forum/cloud-gov-support)
 - [ ] Remove them from [the cloud.gov inquiries Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!forum/cloud-gov-inquiries)
 - [ ] Remove them from the @cloud-gov-team in the Slack Team Directory
-- [ ] Remove them from any IAM roles they hold in AWS
+- [ ] Remove them from any IAM roles they hold in AWS E/W and GovCloud
 - [ ] Remove them from [the list of people working on the project](https://docs.google.com/spreadsheets/d/1mW3tphZ98ExmMxLHPogSpTq8DzYr5Oh8_SHnOTvjRWM/edit#gid=0)
+- [ ] Remove them from DigitalGov Search access for cg-docs
 - [ ] Remove them as invitees for any meetings on the cloud.gov calendar
 - [ ] Remove any special Org or Space roles that their cloud.gov account holds
 - [ ] [Remove their access as an admin](https://docs.cloud.gov/ops/managing-users/#managing-admins) on the platform

--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -87,10 +87,12 @@ For explanations of our theme names, see [this glossary](https://github.com/18F/
 - [ ] Review the main [front end board](https://github.com/18F/cg-dashboard/pulls#boards?repos=55727091,39210774,49169967,40567233&labels=Liberator&showPRs=false) (ensure to filter by the "Liberator" label)
 - [ ] Bookmark link to [design folder](https://drive.google.com/drive/u/1/folders/0BwLqM4Nicmq-bUt0NjRjclFMUEU)
 - [ ] Review the primary cloud.gov sites: [the dashboard](https://dashboard.cloud.gov/#/), [main landing page](https://cloud.gov/), and [documentation](https://docs.cloud.gov/).
+- [ ] [Request access to 18F Google Analytics](https://handbook.18f.gov/google-analytics/), so you can view cloud.gov site analytics ([including for the dashboard](https://docs.google.com/document/d/1gSbP2ak2a3QLpCZIF_KlbQ2QHE6RjDI-7ZnnrJZvMDE/edit))
+- [ ] Ask for an invite to a DigitalGov Search account for cg-docs, so you can configure it and view analytics
 
 ##### If developing
 - [ ] Set up the [landing page](https://github.com/18F/cg-landing), [dashboard](https://github.com/18F/cg-dashboard), [docs](https://github.com/18F/cg-docs), and [cg-style](https://github.com/18F/cg-style) locally
-- [ ] Set up cg-style to be [linked to the other sites locally](https://github.com/18F/cg-style#development-and-contributing-setup).
+- [ ] Set up cg-style to be [linked to the other sites locally](https://github.com/18F/cg-style#development-and-contributing-setup)
 - [ ] Have cloud.gov person send the cg-dashboard testing env vars through Fugacious
 - [ ] Review [dashboard contributing guide](https://github.com/18F/cg-dashboard/CONTRIBUTING.md) and [cg-style standards](https://github.com/18F/cg-style/blob/master/documentation/frontend_standards.md)
 


### PR DESCRIPTION
Just Liberator-specific notes for now! This may be helpful for SkyPorter too, so I put a note in the active issue over there - https://github.com/18F/cg-product/issues/339

I added an onboarding note for Google Analytics but no offboarding note, since once you get access to 18F Analytics, you have access to all 18F analytics (not just cloud.gov), and you don't need to be removed from that if you're just leaving cloud.gov to work on another 18F project.