### PR TITLE
Remove cloud foundry UI review item

### DIFF
--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -108,7 +108,6 @@ For explanations of our theme names, see [this glossary](https://github.com/18F/
 - [ ] Review the [cg-style styleguide](https://pages.18f.gov/cg-style/) to get a sense of the global cloud.gov visual style.
 - [ ] Review the [US Web Design Standards](https://standards.usa.gov/) as cg-style was built from it.
 - [ ] Review the dashboard: current [prod](https://dashboard.cloud.gov/#/), [master](https://dashboard-master.apps.cloud.gov/#/) and [staging](https://dashboard-staging.apps.cloud.gov/#/)
-- [ ] Review the Cloud Foundry [community UI](http://ui.apps.cloud.gov/), a UI that members of the Cloud Foundry community created and that we're using a basis for our own dashboard design
 
 #### HighBar-specific items
 - [ ] Bookmark [the HighBar kanban board view](https://github.com/18F/cg-product#boards?labels=HighBar&showPRs=false)


### PR DESCRIPTION
Removed cloud foundry UI review item from under the "for review" section. 
Reviewing this content doesn't seem to be necessary any longer.
https://gsa-tts.slack.com/archives/cloud-gov/p1480435025003298