### PR TITLE
Add nonpublic information training to onboarding checklist

### DIFF
--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -53,6 +53,7 @@ These items help us fulfill security and compliance requirements (including for 
 - [ ] Read the [Continuous Monitoring Strategy](https://cloud.gov/docs/ops/continuous-monitoring/), particularly the [cloud.gov team responsibilities](https://cloud.gov/docs/ops/continuous-monitoring/#cloud-gov-team).
 - [ ] Coordinate with your onboarding buddy to go through Contingency Planning training within 10 days if you'll be taking on a significant role in our Contingency Planning processes (or annually if not).
 - [ ] Read the [Configuration Management Plan](https://docs.cloud.gov/ops/configuration-management/).
+- [ ] Coordinate with your onboarding buddy to go through [nonpublic information training](https://docs.google.com/presentation/d/1uB4MlGCu8ZYUxjKVZKwicQ95MvLxaT4Mh93y6w79GPw/edit#slide=id.p) within 60 days of joining the team (and annually after that).
 - [ ] Subscribe to [the cloud.gov team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&ctz=America/Los_Angeles) (click the + in the bottom right) so you know when assorted team meetings are happening in the various streams
 - [ ] Subscribe (through the GitHub watch function) to the [cg-site](https://github.com/18F/cg-site) GitHub repository notifications
 


### PR DESCRIPTION
This will help us fulfill our FedRAMP requirements, as described in https://github.com/18F/cg-product/issues/546 - AC-22 part b prescribes that we need to have training for this. AC-22 doesn't prescribe a specific timeline, so I matched the IR training timeline.