### PR TITLE
Add training tracker to onboarding/offboarding checklists

### DIFF
--- a/OffboardingChecklist.md
+++ b/OffboardingChecklist.md
@@ -22,7 +22,9 @@ In order to complete LeavingPerson's exit from the cloud.gov team, the assignee 
 
 ## Assignee
 - [ ] Remove them from the @cloud-gov-team in the Slack Team Directory
-- [ ] Remove them from [team roster](https://docs.google.com/spreadsheets/d/1mW3tphZ98ExmMxLHPogSpTq8DzYr5Oh8_SHnOTvjRWM/edit#gid=0) and [squad list](https://github.com/18F/cg-product/blob/master/DeliveryProcess.md#squads)
+- [ ] Remove them from the [team roster](https://docs.google.com/spreadsheets/d/1mW3tphZ98ExmMxLHPogSpTq8DzYr5Oh8_SHnOTvjRWM/edit#gid=0)
+- [ ] Remove them from the [squad list](https://github.com/18F/cg-product/blob/master/DeliveryProcess.md#squads)
+- [ ] Remove them from the [training tracker](https://docs.google.com/spreadsheets/d/1hqU6cNeEB293OT0j3OvbdAFRkrf2zDOrPVxGfnr4sSw/edit#gid=0)
 - [ ] Remove them as invitees for any meetings on the cloud.gov calendar
 - [ ] If they are leaving 18F ensure the [18F Handbook exit process](https://handbook.18f.gov/leaving-18f/#offboarding-process) has been kicked off via the 18F talent team
 

--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -134,6 +134,7 @@ For explanations of our theme names, see [this glossary](https://github.com/18F/
 These items help us fulfill security and compliance requirements (including for FedRAMP).
 
 - [ ] Make sure they're in [the list of people working on the project](https://docs.google.com/spreadsheets/d/1mW3tphZ98ExmMxLHPogSpTq8DzYr5Oh8_SHnOTvjRWM/edit#gid=0).
+- [ ] Add their name, whether they're Cloud Ops (Atlas/AgentQ), and the date they joined the team to the [training tracker](https://docs.google.com/spreadsheets/d/1hqU6cNeEB293OT0j3OvbdAFRkrf2zDOrPVxGfnr4sSw/edit#gid=0).
 - [ ] Add them to the @cloud-gov-team [in Slack’s Team Directory](https://get.slack.help/hc/en-us/articles/212906697-User-Groups#edit-a-user-group), which also adds them to the right channels (or ask #admins-slack if you don't have permission to do this).
 - [ ] Add them to the recurring cloud.gov meetings that are relevant for them in [the team calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_0samf7guodi7o2jhdp0ec99aks@group.calendar.google.com&ctz=America/Los_Angeles).
 - [ ] Ask `#admins-github` to add them to the [@18F/cloud.gov team](https://github.com/orgs/18F/teams/cloud-gov) on GitHub.


### PR DESCRIPTION
Keeping this updated will help us fulfill our compliance requirements (https://github.com/18F/cg-product/issues/216). It also means we now have yet another place where we need to track people's names, teams, and start dates, but I don't see an easy solution for that - suggestions welcome.