### PR TITLE
Add offboarding item for removing people from the CF community org cloud.gov team

### DIFF
--- a/OffboardingChecklist.md
+++ b/OffboardingChecklist.md
@@ -29,6 +29,7 @@ In order to complete LeavingPerson's exit from the cloud.gov team, the assignee 
 
 ## Product Owner
 - [ ] Remove them from [GitHub teams that start with cloud-gov](https://github.com/orgs/18F/teams?utf8=%E2%9C%93&query=cloud-gov)
+- [ ] Remove them from the [Cloud Foundry Community GitHub org cloud.gov team](https://github.com/orgs/cloudfoundry-community/teams/cloud-gov)
 - [ ] Remove their access to Zendesk
 - [ ] Remove their access to StatusPage
 - [ ] Remove their access to PagerDuty


### PR DESCRIPTION
Not sure yet how we want to handle _onboarding_ for this org, but we should at least handle offboarding for it.