### PR TITLE
Update Concourse pipeline examples link

### DIFF
--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -75,7 +75,7 @@ For explanations of our theme names, see [this glossary](https://github.com/18F/
 - [ ] Get to know how UAA is deployed/integrated.
 - [ ] Get familiar with [Terraform](https://www.terraform.io/) by going through the [getting started guide](https://www.terraform.io/intro/getting-started/install.html).
 - [ ] Learn about [Concourse](https://concourse.ci/) and try a [tutorial](https://github.com/starkandwayne/concourse-tutorial).
-- [ ] Check out our [staging](https://ci-stage.cloud.gov/) and [production](https://ci.cloud.gov) Concourse instances, and take a look at some of [our pipelines](https://github.com/18F?utf8=%E2%9C%93&query=cg-deploy).
+- [ ] Check out our [staging](https://ci-stage.cloud.gov/) and [production](https://ci.cloud.gov) Concourse instances, and take a look at some of [our pipelines](https://github.com/search?q=org%3A18F+cg-deploy).
 - [ ] Join [the cloud.gov operations notifications Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!forum/cloud-gov-notifications), so you can see alert information if PagerDuty is unavailable
 - [ ] Join [the Cloud Foundry Slack](http://slack.cloudfoundry.org/).
 - [ ] Get familiar with our AWS setup.


### PR DESCRIPTION
Update the query to yield `cg-deploy`-related repositories.

Before merging, please confirm that this accurately reflects the intent of that link. Thanks!