### PR TITLE
Suspending threat-modeling-every-story DoD until overhead decreases

### DIFF
--- a/DeliveryProcess.md
+++ b/DeliveryProcess.md
@@ -134,7 +134,7 @@ Required for compliance:
 <!-- New software integration check is due to CM-7 (5) part a -->
 <!-- Noah said we need to check with him before integrating new services -->
 
-- The team has used the [threat modeling guide](https://docs.google.com/document/d/14QOvOqWuLtlnJptB5Lw-qA7ClERiMiA8yfxRTD__lbg/edit) to document and analyze any potential security impact of the changes proposed by the story. 
+- _[Pending initial threat-modeling of some key components]_ The team has used the [threat modeling guide](https://docs.google.com/document/d/14QOvOqWuLtlnJptB5Lw-qA7ClERiMiA8yfxRTD__lbg/edit) to document and analyze any potential security impact of the changes proposed by the story. 
 - If the story includes integrating new software (such as a new open source component) into the core platform, the cloud.gov System Owner has approved the plan.
 - If the story includes integrating a new external service (a service outside the cloud.gov FedRAMP authorization boundary) or changing an external service configuration/usage in a way that may have a security/compliance impact, the cloud.gov Authorizing Official has approved the plan.
 


### PR DESCRIPTION
Per Platform Squad retro, we're pausing the requirement to do this on every story until we've done some threat-modeling together as a team to develop consistency and have brought the overhead down.