### PR TITLE
Remove East-West links from PertinentLinks

### DIFF
--- a/PertinentLinks.md
+++ b/PertinentLinks.md
@@ -46,10 +46,8 @@ should be bookmarked and encouraged to check on a regular basis.
 [slack-business]: https://gsa-tts.slack.com/messages/cg-business
 
 [aws-fr-console]: https://signin.amazonaws-us-gov.com/?region=us-gov-west-1
-[aws-console]: http://signin.aws.amazon.com/console/
 
 [cg-dashboard]: https://dashboard.fr.cloud.gov/
-[cg-continuous-integration]: https://ci.cloud.gov/
 [cg-fr-continuous-integration]: https://ci.fr.cloud.gov/
 [cg-drive-folder]: https://drive.google.com/drive/folders/0Bx6EvBXVDWwheUtVckVnOE1pRzA
 


### PR DESCRIPTION
Now that we've standardized to GovCloud, the East-West links are no longer necessary.

(Kin to https://github.com/18F/cg-site/pull/851, but discovered while working on a different ticket.)