### PR TITLE
Change url for staging customers site

### DIFF
--- a/OffboardingChecklist.md
+++ b/OffboardingChecklist.md
@@ -59,4 +59,4 @@ In order to complete LeavingPerson's exit from the cloud.gov team, the assignee 
 ## Customer Team
 - [ ] Delete their account from the customers app.
   - [ ] [Production Site](https://customers.fr.cloud.gov/django-admin/auth/user/)
-  - [ ] [Staging Site](https://customers-staging.fr.cloud.gov/django-admin/auth/user/)
+  - [ ] [Staging Site](https://customers.fr-stage.cloud.gov/django-admin/auth/user/)

--- a/OnboardingChecklist.md
+++ b/OnboardingChecklist.md
@@ -116,7 +116,7 @@ For explanations of our theme names, see [this glossary](https://github.com/18F/
   - [dashboard (govcloud)](https://synthetics.newrelic.com/accounts/907948/monitors/c4fdd474-0f6c-470a-bf9d-a3d839cea2cb/alerts)
 - [ ] Ask the team to add your e-mail address to the customers app.
   - [ ] [Production Site](https://customers.fr.cloud.gov/django-admin/auth/user/)
-  - [ ] [Staging Site](https://customers-staging.fr.cloud.gov/django-admin/auth/user/)
+  - [ ] [Staging Site](https://customers.fr-stage.cloud.gov/django-admin/auth/user/)
 
 ##### If developing
 - [ ] Review the [dashboard contributing guide](https://github.com/18F/cg-dashboard/blob/master/CONTRIBUTING.md) and [`cg-style` standards](https://github.com/18F/cg-style/blob/master/documentation/frontend_standards.md) which help frame what we're looking for in code review.


### PR DESCRIPTION
As a result of https://github.com/18F/cg-customers/pull/5 the location
of the customers staging app moved from the CF prod env to the CF
staging env

This commit reflects the change for onboarding and offboarding purposes