### PR TITLE
Add offboarding step to remove any platform permissions

### DIFF
--- a/OffboardingChecklist.md
+++ b/OffboardingChecklist.md
@@ -50,6 +50,7 @@ In order to complete LeavingPerson's exit from the cloud.gov team, the assignee 
 
 
 ## Cloud Operations
+- [ ] Remove any privileges they have due to membership in the cloud.gov team (even if not in Cloud Ops), such as `admin_ui.read`
 - [ ] Remove them from any IAM roles they hold in AWS GovCloud
 - [ ] [Remove their access as an admin](https://docs.cloud.gov/ops/managing-users/#managing-admins) on the platform
 - [ ] Remove any Org or Space roles that their cloud.gov account holds due to membership in the cloud.gov team (for example, remove them from the `cloud-gov-operators` organization)

--- a/OffboardingChecklist.md
+++ b/OffboardingChecklist.md
@@ -50,9 +50,9 @@ In order to complete LeavingPerson's exit from the cloud.gov team, the assignee 
 
 
 ## Cloud Operations
-- [ ] Remove any privileges they have due to membership in the cloud.gov team (even if not in Cloud Ops), such as `admin_ui.read`
 - [ ] Remove them from any IAM roles they hold in AWS GovCloud
 - [ ] [Remove their access as an admin](https://docs.cloud.gov/ops/managing-users/#managing-admins) on the platform
+- [ ] Remove any privileges that their cloud.gov account has due to membership in the cloud.gov team (even if not in Cloud Ops), such as `admin_ui.read`
 - [ ] Remove any Org or Space roles that their cloud.gov account holds due to membership in the cloud.gov team (for example, remove them from the `cloud-gov-operators` organization)
 - [ ] Confirm the System Owner (or person delegated by System Owner) has removed them from all GitHub teams
 - [ ] Ensure any keys or passwords they had direct access to are rotated


### PR DESCRIPTION
Members of the team outside of Cloud Ops may have limited access of some kind that still needs to be removed, such as having `admin_ui.read` access, so this adds an offboarding step to catch that. I may have used imprecise terminology here; feel free to fix.