### PR TITLE
Integrate SCR rubric into delivery process

### DIFF
--- a/FeatureLifecycle.md
+++ b/FeatureLifecycle.md
@@ -24,7 +24,7 @@ Features progress through these columns in the Feature Kanban on the [the Progra
   - We've received a determination from the JAB TRs as to whether they require a Significant Change Request (SCR) be filed. If the determination is "yes", the card is tagged with `SCR:Yes`. Otherwise the card is tagged with `SCR:No`.
   - If the card is tagged `SCR:Yes`: 
     - The card includes a link to a [Significant Change Request](https://docs.google.com/a/gsa.gov/document/d/16GaDO1xnHrqEEetbonNpo4P10LlGoDHR-jedqBo1yB8/edit?usp=drive_web) format [in Google Drive](https://drive.google.com/drive/folders/0B1cewEqKcWCbU1lSUXhEVUNZWUU).
-    - The SCR has been submitted to the JAB TRs.
+    - The SCR has been signed by the System Owner (or delegate) and submitted to the JAB TRs.
     - The JAB TRs have approved the SCR.
 - Backlog (when the feature is basically well-understood at a high level and awaits squad-level attention)
   - The program commits to taking on the Feature during a PI Planning meeting.

--- a/FeatureLifecycle.md
+++ b/FeatureLifecycle.md
@@ -19,7 +19,7 @@ Features progress through these columns in the Feature Kanban on the [the Progra
   - The card points to any relevant design/research artifacts. Any more detail than that should appear in stories that get parented onto the feature.
   - The card has a WSJF score for `Effort`, and the card is tagged with `WSJF:<value>`.
 - Security Impact Analysis (where we ensure every feature undergoes compliance oversight)
-  - We've reviewed the change against our [significant change rubric](https://cloud.gov/docs/ops/continuous-monitoring/#appendix-significant-change-rubric).
+  - We've reviewed the change against our [significant change rubric](https://cloud.gov/docs/ops/continuous-monitoring/#appendix-significant-change-rubric). We may use the [threat modeling guide](https://docs.google.com/document/d/14QOvOqWuLtlnJptB5Lw-qA7ClERiMiA8yfxRTD__lbg/edit) to assist with documenting and analyzing potential security impact.
   - If discussion with TRs or a SCR may be required, we've summarized the feature for the JAB TRs in (or in a doc linked from) the [agenda for the next bi-weekly JAB Technical Reviewers (TRs) meeting](https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit#).
   - We've received a determination from the JAB TRs as to whether they require a Significant Change Request (SCR) be filed. If the determination is "yes", the card is tagged with `SCR:Yes`. Otherwise the card is tagged with `SCR:No`.
   - If the card is tagged `SCR:Yes`: 

--- a/FeatureLifecycle.md
+++ b/FeatureLifecycle.md
@@ -19,7 +19,8 @@ Features progress through these columns in the Feature Kanban on the [the Progra
   - The card points to any relevant design/research artifacts. Any more detail than that should appear in stories that get parented onto the feature.
   - The card has a WSJF score for `Effort`, and the card is tagged with `WSJF:<value>`.
 - Security Impact Analysis (where we ensure every feature undergoes compliance oversight)
-  - We've summarized the feature for the JAB TRs in (or in a doc linked from) the [agenda for the next bi-weekly JAB Technical Reviewers (TRs) meeting](https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit#).
+  - We've reviewed the change against our [significant change rubric](https://cloud.gov/docs/ops/continuous-monitoring/#appendix-significant-change-rubric).
+  - If discussion with TRs or a SCR may be required, we've summarized the feature for the JAB TRs in (or in a doc linked from) the [agenda for the next bi-weekly JAB Technical Reviewers (TRs) meeting](https://docs.google.com/document/d/1jGddQkjkQ6e9B0UTq9hfQqHe0btAbTeBGL_DxkozAcg/edit#).
   - We've received a determination from the JAB TRs as to whether they require a Significant Change Request (SCR) be filed. If the determination is "yes", the card is tagged with `SCR:Yes`. Otherwise the card is tagged with `SCR:No`.
   - If the card is tagged `SCR:Yes`: 
     - The card includes a link to a [Significant Change Request](https://docs.google.com/a/gsa.gov/document/d/16GaDO1xnHrqEEetbonNpo4P10LlGoDHR-jedqBo1yB8/edit?usp=drive_web) format [in Google Drive](https://drive.google.com/drive/folders/0B1cewEqKcWCbU1lSUXhEVUNZWUU).

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -51,7 +51,7 @@ Required for compliance:
 <!-- Security impact analysis is due to CM-3 part b, CM-4 -->
 <!-- New software integration check is due to CM-7 (5) part a -->
 
-- The work has received Security Impact Analysis, and we have completed any associated work with our System Owner and JAB TRs. If this wasn't already performed as part of the [feature lifecycle](FeatureLifecycle.md), we have followed that Security Impact Analysis process at this stage for this story.
+- If the story is **not** part of a larger feature which has already undergone [Security Impact Analysis](FeatureLifecycle.md#security-impact-analysis), we have applied that same Security Impact Analysis evaluation process for this story and filed any necessary SCR.
 
 #### Ready
 

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -44,17 +44,14 @@ Before advancing a card from one column to the next on the board, it should meet
 - Has testable/demoable Acceptance Criteria that we expect to be able to check off to help us understand when the work is done. (Try wording them as [Gherkin](https://en.wikipedia.org/wiki/Behavior-driven_development#Behavioural_specifications), and use [GFM checklists](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments) for them).
 - Discussed by the team and implementation sketched (use more checklists here).
 - We believe the benefit of the story is easily deliverable within in a few days of concentrated work (otherwise, split it into smaller stories!)
-- Any authentication/authorization and data persistence points are discussed and requirements are addressed via Acceptance Criteria (e.g., "Authenticate using [login.cloud.gov]" or "Any ephemeral data resulting from usage is backed up/recoverable").
+- Any authentication/authorization and data persistence points are discussed and requirements are addressed via Acceptance Criteria (e.g., "Authenticate using [login.fr.cloud.gov]" or "Any ephemeral data resulting from usage is backed up/recoverable").
 - There's a communication plan for any user-visible changes which require their attention/action.
 
 Required for compliance: 
 <!-- Security impact analysis is due to CM-3 part b, CM-4 -->
 <!-- New software integration check is due to CM-7 (5) part a -->
-<!-- Noah said we need to check with him before integrating new services -->
 
-- _[Pending initial threat-modeling of some key components]_ The team has used the [threat modeling guide](https://docs.google.com/document/d/14QOvOqWuLtlnJptB5Lw-qA7ClERiMiA8yfxRTD__lbg/edit) to document and analyze any potential security impact of the changes proposed by the story. 
-- If the story includes integrating new software (such as a new open source component) into the core platform, the cloud.gov System Owner has approved the plan.
-- If the story includes integrating a new external service (a service outside the cloud.gov FedRAMP authorization boundary) or changing an external service configuration/usage in a way that may have a security/compliance impact, the cloud.gov Authorizing Official has approved the plan.
+- The work has received Security Impact Analysis, and we have completed any associated work with our System Owner and JAB TRs. If this wasn't already performed as part of the [feature lifecycle](FeatureLifecycle.md), we have followed that Security Impact Analysis process at this stage for this story. We may use the [threat modeling guide](https://docs.google.com/document/d/14QOvOqWuLtlnJptB5Lw-qA7ClERiMiA8yfxRTD__lbg/edit) to assist with documenting and analyzing potential security impact.
 
 #### Ready
 

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -51,7 +51,7 @@ Required for compliance:
 <!-- Security impact analysis is due to CM-3 part b, CM-4 -->
 <!-- New software integration check is due to CM-7 (5) part a -->
 
-- The work has received Security Impact Analysis, and we have completed any associated work with our System Owner and JAB TRs. If this wasn't already performed as part of the [feature lifecycle](FeatureLifecycle.md), we have followed that Security Impact Analysis process at this stage for this story. We may use the [threat modeling guide](https://docs.google.com/document/d/14QOvOqWuLtlnJptB5Lw-qA7ClERiMiA8yfxRTD__lbg/edit) to assist with documenting and analyzing potential security impact.
+- The work has received Security Impact Analysis, and we have completed any associated work with our System Owner and JAB TRs. If this wasn't already performed as part of the [feature lifecycle](FeatureLifecycle.md), we have followed that Security Impact Analysis process at this stage for this story.
 
 #### Ready
 


### PR DESCRIPTION
*Do not merge until the SCR rubric PR is merged (https://github.com/18F/cg-site/pull/1059). This also needs review by the cloud.gov Program Manager before merge.*

Changes to feature lifecycle:
* Before we put a feature into the meeting agenda for discussion with JAB TRs, we review it against our SCR rubric. Some changes do not need any discussion with TRs.
* Move the threat modeling guide to this stage, as a supplement to SCR analysis.

Changes to story lifecycle:
* If a story has not received security impact analysis as part of a feature, it needs security impact analysis at the story stage. This is to catch "gravel" stories that pop up outside of features.
* The steps about reviewing with the System Owner or the AO belong in the Security Impact Analysis and formal SCR rubric, not in this grooming stage.

Non-blocking questions before merge, mainly for Program Manager and System Owner:
* Question: is this the right place for the threat modeling guide? How might we integrate the threat modeling guide in a more practical way that is required at the appropriate step, rather than as an optional supplement jammed in there?
* CM-3 part b and CM-7 a require System Owner review and approval before significant changes. Do we need to add anything more to these processes to ensure we're getting proper System Owner review and approval, or is this already covered by having the SCRs signed by the System Owner or their delegate?
* Is there anything relevant we should integrate into https://github.com/18F/cg-product/blob/master/ConMonChecklist.md or link from there?