### PR TITLE
[WIP] DoD entry for documenting integration test dependencies

### DIFF
--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -67,8 +67,9 @@ Required for compliance:
 - Test coverage exists and overall coverage hasn't been reduced.
 - User-facing and internal operation docs have been updated.
 - Demoable to other people in their own time (e.g., staging environment, published branch).
-- Any deployment is repeatable (e.g., at least documented to increase [bus factor](https://en.wikipedia.org/wiki/Bus_factor) beyond one) and if possible automated via CI/CD.
-  - If the deployment is difficult to automate, then a story for making it automated is created at the top of `Triage`.
+- Any deployment is repeatable (e.g., at least documented to increase [bus factor](https://en.wikipedia.org/wiki/Bus_factor) beyond one) and if possible automated via use of IaaC or CI/CD.
+  - If the deployment is too difficult to automate without blowing up the story, then a separate story for making it automated is created at the top of `Grooming` so it'll be discussed in the next grooming/planning session.
+- All known dependencies for integration tests are explicitly captured as [triggering resources](https://concoursetutorial.com/basics/triggers/) in the relevant Concourse pipeline
 - All UAA accounts are provisioned using the Cloud Foundry secrets or the cloud.gov [service account](https://cloud.gov/docs/services/cloud-gov-service-account/) or [identity provider](https://cloud.gov/docs/services/cloud-gov-identity-provider/) services.
 
 Required for compliance:

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -67,8 +67,8 @@ Required for compliance:
 - Test coverage exists and overall coverage hasn't been reduced.
 - User-facing and internal operation docs have been updated.
 - Demoable to other people in their own time (e.g., staging environment, published branch).
-- Any deployment is repeatable (e.g., at least documented to increase [bus factor](https://en.wikipedia.org/wiki/Bus_factor) beyond one) and if possible automated via use of IaaC or CI/CD.
-  - If the deployment is too difficult to automate without blowing up the story, then a separate story for making it automated is created at the top of `Grooming` so it'll be discussed in the next grooming/planning session.
+- Any deployment is repeatable (e.g., at least documented to increase [bus factor](https://en.wikipedia.org/wiki/Bus_factor) beyond one) and if possible automated via use of infrastructure-as-code or CI/CD.
+  - If the deployment is too difficult to automate without inflating the story beyond a reasonable size, then create a separate story to automate it at the top of `Grooming` so we'll be sure to discuss it in the next grooming/planning session.
 - All known dependencies for integration tests are explicitly captured as [triggering resources](https://concoursetutorial.com/basics/triggers/) in the relevant Concourse pipeline
 - All UAA accounts are provisioned using the Cloud Foundry secrets or the cloud.gov [service account](https://cloud.gov/docs/services/cloud-gov-service-account/) or [identity provider](https://cloud.gov/docs/services/cloud-gov-identity-provider/) services.
 


### PR DESCRIPTION
In order to ensure we'll predict/detect outages we should have known about in staging if only we'd been more thorough about documenting our tests' dependencies in our pipelines, we want our DoD to include ensuring all known dependencies for integration tests are explicitly captured in pipelines during `In Progress`.