### PR TITLE
Replace dead references to Favro with links to Jira

### DIFF
--- a/ContentGuide.md
+++ b/ContentGuide.md
@@ -38,7 +38,7 @@ Use these exact strings (keeping this spelling, capitalization, punctuation, and
 * **ElastiCache**
 * **Elasticsearch**
 * **ELK**
-* **Favro**
+* **Jira**
 * **FedRAMP**
 * FISMA levels are **Low**, **Moderate** (not *Medium*), and **High**.
 * **Git**

--- a/OffboardingChecklist.md
+++ b/OffboardingChecklist.md
@@ -35,7 +35,6 @@ In order to complete LeavingPerson's exit from the cloud.gov team, the assignee 
 - [ ] Remove their access to [StatusPage](https://manage.statuspage.io/organizations/btc69fwyvjh7/team) - likely have to ask devops@gsa.gov or #infrastructure
 - [ ] Remove their access to [PagerDuty](https://18fi.pagerduty.com/users)
 - [ ] Remove their access to [New Relic](https://rpm.newrelic.com/accounts/907948)
-- [ ] Remove their access to [Favro](https://favro.com/organization/1e11108a2da81e3bd7153a7a/1c6c9af1003b58d597b43ef4?onShow=administration)
 - [ ] Remove them from [the cloud.gov team Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!managemembers/cloud-gov/members/active)
 - [ ] Remove them from [the cloud.gov notifications Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!managemembers/cloud-gov-notifications/members/active)
 - [ ] Remove them from [the cloud.gov inquiries Google Group](https://groups.google.com/a/gsa.gov/forum/?hl=en#!managemembers/cloud-gov-inquiries/members/active)

--- a/OffboardingChecklist.md
+++ b/OffboardingChecklist.md
@@ -10,7 +10,7 @@ When someone leaves the cloud.gov team
 4. Replace "LeavingPerson" with the leaving person's name
 5. Submit the issue
 6. Assign the issue to the person who bravely volunteered to handle the person's offboarding
-7. Put the issue into the "In Progress" pipeline in Favro
+7. Put the issue into the "In Progress" pipeline in Jira
 
 ---
 

--- a/PertinentLinks.md
+++ b/PertinentLinks.md
@@ -33,7 +33,7 @@ should be bookmarked and encouraged to check on a regular basis.
 #### BizOps-specific items
 
 - [BizOps Slack][slack-business] :lock:
-- [BizOps Trello board]: https://trello.com/b/MSA7McuX/cloudgov-bu
+- [BizOps Trello board](https://trello.com/b/MSA7McuX/cloudgov-bu)
 
 [jira-all]: https://cm-jira.usa.gov/secure/PortfolioPlanView.jspa?id=138&sid=138#backlog
 [jira-platform]: https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=1926&projectKey=CG&quickFilter=8141

--- a/PertinentLinks.md
+++ b/PertinentLinks.md
@@ -33,7 +33,7 @@ should be bookmarked and encouraged to check on a regular basis.
 #### BizOps-specific items
 
 - [BizOps Slack][slack-business] :lock:
-- [BizOps Favro board][favro-business]
+- [BizOps Trello board]: https://trello.com/b/MSA7McuX/cloudgov-bu
 
 [jira-all]: https://cm-jira.usa.gov/secure/PortfolioPlanView.jspa?id=138&sid=138#backlog
 [jira-platform]: https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=1926&projectKey=CG&quickFilter=8141

--- a/ProgramRituals.md
+++ b/ProgramRituals.md
@@ -26,8 +26,8 @@ Key recordable outcomes of PI planning should include:
  - PI objectives and risks for the whole program (ideally these get plopped into the "Inspect" presentation template as a first draft for that meeting immediately after PI planning ends) 
 
 These often take the form of:
- - Prioritized high-level features (Favro)
- - Backlog of epics and related stories (Favro)
+ - Prioritized high-level features (Jira)
+ - Backlog of epics and related stories (Jira)
  - Planning Mural (Mural.ly)
 
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ When we're well-staffed, we break into sub-teams around the different themes, bu
 
 Here are the themes of work we've identified so far and the products for which they're responsible.
 
-- [Platform](https://favro.com/organization/1e11108a2da81e3bd7153a7a/68a186775e1a0ee297ee81ed) (#cg-platform)
+- [Platform]https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=1926&projectKey=CG&view=detail) (#cg-platform)
   - The Platform theme aims to keep a solid, dependable, tested, and proven platform up and running strong for everyone in government to use. This includes a lot of automation; infrastructure-as-code is the key theme.
   - "cloud.gov" refers to the [cloud.gov](https://cloud.gov) Platform-as-a-Service (PaaS), which is cloud.gov's first product. The PaaS provides a comfortable abstraction which handles cloud-based operations and greatly reduces the complications of infrastructure management for delivery teams. Our PaaS builds on the widely-used and open source [Cloud Foundry](https://www.cloudfoundry.org/), deployed with practices geared toward meeting [strict government compliance requirements](https://en.wikipedia.org/wiki/Federal_Information_Security_Management_Act_of_2002).
   - This theme includes activity related to the FedRAMP authorization of cloud.gov. Compliance auditing and pen-testing activities are coordinated here, as well as necessary remediation that results.
-- [Customer](https://favro.com/organization/1e11108a2da81e3bd7153a7a/0b64f44bc57f65052fad8244) (#cg-customer)
+- [Customer](https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=1929) (#cg-customer)
   - The Customer theme aims to make infrastructure and deployment self-service and easy to use, and ensure people can find answers when they need them.
   - Customer theme encompasses all the user- and tenant-facing features of cloud.gov. That includes UX for web UI, billing workflow, as well as overall design, branding, IA, and integration in our customer-facing presence.
   - Customer focuses on designing the customer experience of cloud.gov from a prospective customer's inquiry about the product through a new customer's onboarding and early use. This includes ongoing user research to understand customer needs and to improve customer interactions, content strategy (including content development and information architecture for our website) to educate customers about our offerings, and other work related to evangelism and training.
 
 In addition to squads, we have a business unit (BU), which, in addition to guiding cloud.gov's business-related decisions, acts as the "front-office" for our customers and stakeholders. The BU consists of cloud.gov's Director and Deputy Director and represents the product in direct communication with customers as they progress from the what-is-this-thing to the productively-using-the-platform-on-their-own stage.
 
-We keep separate backlogs, kanban boards, etc. reflecting each of these themes of work. The [`cg PaaS Program` kanban board](https://favro.com/organization/1e11108a2da81e3bd7153a7a/0b64f44bc57f65052fad8244) consolidates the activity of all of these sub-themes into a single program-level view against higher-level objectives.
+We keep separate backlogs, kanban boards, etc. reflecting each of these themes of work. The [`cg PaaS Program` kanban board](https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=1918) consolidates the activity of all of these sub-themes into a single program-level view against higher-level objectives.
 
 Other notable Slack channels for 18F folk
 
@@ -45,11 +45,11 @@ Other notable Slack channels for 18F folk
 
 ## Roadmap and ChangeLog
 
-We publish [roadmap and recent-change information for the overall cloud.gov effort](https://favro.com/organization/1e11108a2da81e3bd7153a7a/698af2c70dcb8da70f612abd), exposed for public consumption and tagged by primary theme. Features are listed in planning increments (PIs) of around three months. Note this information is live, and the priority of anything beyond the next three months is subject to change at any time!
+We publish [roadmap and recent-change information for the overall cloud.gov effort](https://cm-jira.usa.gov/secure/PortfolioProgramView.jspa?id=3) tagged by primary theme. Features are listed in planning increments (PIs) of around three months. Note this information is live, and the priority of anything beyond the next three months is subject to change at any time!
 
 ## Following our work in progress
 
-We are using [Favro](https://favro.com) to provide a top-level kanban board and burndown charts showing the status of related work happening across the many themes of work.
+We have a top-level [Jira](https://cm-jira.usa.gov/projects/CG/summary) project collecting our various kanban boards.
 
 ## Joining and leaving our team
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ When we're well-staffed, we break into sub-teams around the different themes, bu
 
 Here are the themes of work we've identified so far and the products for which they're responsible.
 
-- [Platform]https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=1926&projectKey=CG&view=detail) (#cg-platform)
+- [Platform](https://cm-jira.usa.gov/secure/RapidBoard.jspa?rapidView=1926&projectKey=CG&view=detail) (#cg-platform)
   - The Platform theme aims to keep a solid, dependable, tested, and proven platform up and running strong for everyone in government to use. This includes a lot of automation; infrastructure-as-code is the key theme.
   - "cloud.gov" refers to the [cloud.gov](https://cloud.gov) Platform-as-a-Service (PaaS), which is cloud.gov's first product. The PaaS provides a comfortable abstraction which handles cloud-based operations and greatly reduces the complications of infrastructure management for delivery teams. Our PaaS builds on the widely-used and open source [Cloud Foundry](https://www.cloudfoundry.org/), deployed with practices geared toward meeting [strict government compliance requirements](https://en.wikipedia.org/wiki/Federal_Information_Security_Management_Act_of_2002).
   - This theme includes activity related to the FedRAMP authorization of cloud.gov. Compliance auditing and pen-testing activities are coordinated here, as well as necessary remediation that results.

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -8,7 +8,7 @@ Stories progress through these columns (although there is some variation from sq
 - Backlog (when they are sequenced alongside other stories prioritized for attention)
 - Icebox (where they go when they are not planned to get attention any time soon)
 
-*Note that Triage and Icebox lists are typically at the left in Jira. This is because those lists tend to get loooooong. By separating them from the board, it remains easy to scroll around when you have multiple boards in your collection.* 
+*Note that Triage and Icebox lists are typically not represented on our kanban boards. This is because those lists tend to get loooooong. By separating them from the board, it remains easy to scroll around a busy board full of stuff you're actually working on soon.* 
 - Grooming (when they're being refined for implementation)
 - Ready (when they're in a shovel-worthy state, just waiting for team capacity to do the work)
 - In Progress (when someone is actively working on the issue)

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -8,7 +8,7 @@ Stories progress through these columns (although there is some variation from sq
 - Backlog (when they are sequenced alongside other stories prioritized for attention)
 - Icebox (where they go when they are not planned to get attention any time soon)
 
-*Note that Triage and Icebox lists are typically at the left in Favro. This is because those lists tend to get loooooong. By separating them from the board, it remains easy to scroll around when you have multiple boards in your collection.* 
+*Note that Triage and Icebox lists are typically at the left in Jira. This is because those lists tend to get loooooong. By separating them from the board, it remains easy to scroll around when you have multiple boards in your collection.* 
 - Grooming (when they're being refined for implementation)
 - Ready (when they're in a shovel-worthy state, just waiting for team capacity to do the work)
 - In Progress (when someone is actively working on the issue)


### PR DESCRIPTION
I really hate that we have to refer to Jira publicly at all because I know it turns people off, and it sucks that these links are behind authentication rather than public, but that's the way the compliance cookie crumbles. 🤷‍♂️