### PR TITLE
Add details to our story and feature lifecycle for SA-11

### DIFF
--- a/FeatureLifecycle.md
+++ b/FeatureLifecycle.md
@@ -37,6 +37,7 @@ When the feature is basically well-understood at a high level and awaits squad-l
 While implementation is in progress.
 - It should be possible to find the set of stories related to the feature.
 - The feature is tracked against the Program Increment (PI) where we suspect it'll be delivered.
+- This feature has a documented plan for how we'll test the security of this feature (including automated testing).
 ### Security Impact Analysis
 Where we ensure every feature undergoes compliance oversight.
 - We've reviewed the feature for impact according to our [significant change rubric](https://cloud.gov/docs/ops/continuous-monitoring/#appendix-significant-change-rubric).

--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -50,8 +50,10 @@ Before advancing a card from one column to the next on the board, it should meet
 Required for compliance: 
 <!-- Security impact analysis is due to CM-3 part b, CM-4 -->
 <!-- New software integration check is due to CM-7 (5) part a -->
+<!-- Security test planning is due to SA-11 part a -->
 
 - If the story is **not** part of a larger feature which has already undergone [Security Impact Analysis](FeatureLifecycle.md#security-impact-analysis), we have applied that same Security Impact Analysis evaluation process for this story and filed any necessary SCR.
+- If necessary, the story includes a security testing plan. For example, the ACs include automated tests and alerts for unexpected behavior.
 
 #### Ready
 


### PR DESCRIPTION
https://nvd.nist.gov/800-53/Rev4/control/SA-11 requires "Create and implement a security assessment plan" as part of implementation. We need to make this more explicit in our planning processes, so @mogul and I added simple steps to our story and feature lifecycle to make this clear.

We would like review from our Cloud Operations engineers and @alexcsmith23.