### PR TITLE
Add explicit Feature and Story templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,33 @@
+---
+name: Feature
+about: Suggest an idea for this project
+title: "[short, single-line summary of the feature]"
+labels: ''
+assignees: ''
+
+---
+
+# What we're after
+[a description of a goal, new capability, or change in the product]
+
+## Hypothesized benefit(s)/why:**
+* [a stakeholder who will benefit and how]
+* [benefit 2]
+* [another feature this would enable]
+
+## Potential metrics
+* [a metric that might be useful in measuring progress/completion]
+* [another metric]
+
+---
+### Further context for those unfamiliar with what we're doing
+
+[add any background context necessary to understand what this feature is about or why it's needed.]
+
+[list what you would expect to the feature to include in more detail. talk about any critical workflows. For example "cloud.gov should allow users to request and view the options available for an SQS service, create an SQS service instance for their Cloud Foundry space, and associate/disassociate the SQS service instance with one or more apps. When the Cloud Foundry service instance is deleted, the SQS service that was instantiated upon service creation and any credentials issued for bind operations should be deleted as well.""]
+
+### Notes for implementers
+
+- [Pointers to relevant languages, components, frameworks, prior art/examples, user research, mockups, etc.]
+- [a technical sketch if we're confident of how to approach implementation]
+- [Example: "We need to create a new broker. Get familiar with [the docs](https://docs.cloudfoundry.org/services/overview.html). [Broker API](https://github.com/pivotal-cf/brokerapi) is a good starting point. Implementation can be done with any AWS account; no access to existing cloud.gov infrastructure should be needed to develop or demo it. The behavior can be demonstrated via exercise of the broker’s REST APIs.]

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -26,6 +26,9 @@ assignees: ''
 
 [list what you would expect to the feature to include in more detail. talk about any critical workflows. For example "cloud.gov should allow users to request and view the options available for an SQS service, create an SQS service instance for their Cloud Foundry space, and associate/disassociate the SQS service instance with one or more apps. When the Cloud Foundry service instance is deleted, the SQS service that was instantiated upon service creation and any credentials issued for bind operations should be deleted as well.""]
 
+### Security considerations
+[note any potential changes to security boundaries, practices, documentation, risk]
+
 ### Notes for implementers
 
 - [Pointers to relevant languages, components, frameworks, prior art/examples, user research, mockups, etc.]

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,25 @@
+---
+name: Story
+about: Suggest a new story for this project
+title: "[short phrase distinguishing this from other Stories]"
+labels: ''
+assignees: ''
+
+---
+
+In order to [reason/outcome/goal], [someone or "we"] want [a specific change in product implementation/behavior]
+
+## Acceptance Criteria
+* [ ] GIVEN [a precondition] \
+  AND [another precondition]
+  WHEN [test step] \
+  AND [test step]
+  THEN [verification step]
+  AND [verification step]
+
+--- 
+
+## Implementation sketch
+[links to background notes, sketches, and/or relevant documentation
+* [ ] [first thing to do]
+* [ ] [another thing to do]

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -13,8 +13,8 @@ In order to [reason/outcome/goal], [someone or "we"] want [a specific change in 
 * [ ] GIVEN [a precondition] \
   AND [another precondition]
   WHEN [test step] \
-  AND [test step]
-  THEN [verification step]
+  AND [test step] \
+  THEN [verification step] \
   AND [verification step]
 
 --- 

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -19,6 +19,9 @@ In order to [reason/outcome/goal], [someone or "we"] want [a specific change in 
 
 --- 
 
+## Security considerations
+[note any potential changes to security boundaries, practices, documentation, risk that arise directly from this story]
+
 ## Implementation sketch
 [links to background notes, sketches, and/or relevant documentation
 * [ ] [first thing to do]


### PR DESCRIPTION
Now that we expect to wrangle stories and features directly via GitHub+ZenHub, I want to bring these templates directly into the repository workflow.